### PR TITLE
update example links to integration tests

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -11,8 +11,8 @@ PHP-VCR records your test suite's HTTP interactions and replays them during futu
 
 There are some examples how to use PHP-VCR in a project:
 
- * [SOAP Weather API test](https://github.com/php-vcr/php-vcr-examples/tree/master/soap)
- * [Curl Github API test](https://github.com/php-vcr/php-vcr-examples/tree/master/guzzle)
+ * [SOAP Weather API test](https://github.com/php-vcr/php-vcr/tree/master/tests/integration/soap)
+ * [Curl Github API test](https://github.com/php-vcr/php-vcr/tree/master/tests/integration/guzzle)
 
 ## Library hooks
 

--- a/index.html
+++ b/index.html
@@ -124,8 +124,8 @@ title: PHP-VCR | Record HTTP interactions while testing
           <h3>Code Examples</h3>
             <p>
                 Learn how to use PHP-VCR with:<br />
-                <a href="https://github.com/php-vcr/php-vcr-examples/tree/master/soap">SoapClient</a>
-                and <a href="https://github.com/php-vcr/php-vcr-examples/tree/master/guzzle">Guzzle</a>
+                <a href="https://github.com/php-vcr/php-vcr/tree/master/tests/integration/soap">SoapClient</a>
+                and <a href="https://github.com/php-vcr/php-vcr/tree/master/tests/integration/guzzle">Guzzle</a>
             </p>
         </div>
       </div>


### PR DESCRIPTION
Updated the links in the homepage/docs page to point to updated examples (currently they link to deprecated examples)